### PR TITLE
Remove tags prefix

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -11,7 +11,7 @@ locals {
 }
 
 module "roles_to_principals" {
-  source   = "../account-map/modules/roles-to-principals"
+  source   = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/roles-to-principals?ref=v1.535.3"
   context  = module.this.context
   role_map = {}
 }

--- a/src/provider-datadog.tf
+++ b/src/provider-datadog.tf
@@ -1,5 +1,5 @@
 module "datadog_configuration" {
-  source  = "github.com/cloudposse-terraform-components/aws-datadog-credentials//src/modules/datadog_keys?ref=tags/v1.535.2"
+  source  = "github.com/cloudposse-terraform-components/aws-datadog-credentials//src/modules/datadog_keys?ref=v1.535.2"
   enabled = true
   context = module.this.context
 }

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -14,6 +14,6 @@ provider "aws" {
 }
 
 module "iam_roles" {
-  source  = "../account-map/modules/iam-roles"
+  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles?ref=v1.535.3"
   context = module.this.context
 }


### PR DESCRIPTION
## what
* The change updates the `source` URL for modules to remove the `tags/` prefix in the version reference.

## why
* Terraform handles incorrectly git paths which have slashes in ref parameter

## references
* https://github.com/hashicorp/go-getter/issues/469
* https://github.com/cloudposse-terraform-components/aws-datadog-credentials/pull/33
* https://github.com/cloudposse/test-harness/pull/56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the reference format for the Datadog Terraform module without changing its version or functionality.
  - Updated the IAM roles module source to a versioned remote GitHub repository for improved module management.
  - Changed the source of the roles-to-principals module to a versioned remote GitHub repository for consistent module sourcing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->