### PR TITLE
fix(#78): ECS Component Naming - Change the `ecs/cluster` component to `ecs` and made it configurable

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -22,7 +22,7 @@ module "ecs_cluster" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component = "ecs/cluster"
+  component = "ecs"
 
   context = module.this.context
 }

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -22,7 +22,7 @@ module "ecs_cluster" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component = "ecs"
+  component = var.ecs_cluster_component
 
   context = module.this.context
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -26,3 +26,9 @@ variable "alb_configuration" {
   description = "The configuration to use for the ALB, specifying which cluster alb configuration to use"
   default     = "default"
 }
+
+variable "ecs_cluster_component" {
+  type        = string
+  description = "Component name used to lookup the ECS cluster remote state"
+  default     = "ecs"
+}


### PR DESCRIPTION
## what
* Change the `ecs/cluster` component to `ecs` 

## why
* Current state the component will fail and not deploy

## references
* https://github.com/cloudposse-terraform-components/aws-datadog-private-location-ecs/issues/78
* `closes #78`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made the ECS cluster reference configurable (replacing a hard-coded value) via a new configuration input, allowing environments to specify which ECS cluster state to use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->